### PR TITLE
Create an ad-hoc shell environment for ease of use. 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ dist/
 paket-files/
 
 
-#Direnv
+# Direnv
 .direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ dist/
 
 # Paket dependency manager
 paket-files/
+
+
+#Direnv
+.direnv/

--- a/app.fsproj
+++ b/app.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1702272962,
+        "narHash": "sha256-D+zHwkwPc6oYQ4G3A1HuadopqRwUY/JkMwHz1YF7j4Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,9 @@ color="always"
               '';
 	    };
 	  in
-	  ''
+	    ''
+mkdir -p .direnv
+touch .direnv/paket.dependencies
 cat ${npmrc} > .npmrc
 	  '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    utils.url = github:numtide/flake-utils;
+    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+      in
+     {
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            fsharp
+            nodePackages.pnpm
+            nodejs
+	    dotnet-sdk_8
+          ];
+
+	  shellHook = let
+	    npmrc = pkgs.writeTextFile {
+	      name = ".npmrc";
+	      text = ''
+# to ensure bash is used instead of Ubuntu’s default dash
+script-shell="${pkgs.bashInteractive}/bin/bash"
+color="always"
+
+# to fix Vite and Workbox imports
+# shamefully-hoist=true
+              '';
+	    };
+	  in
+	  ''
+cat ${npmrc} > .npmrc
+	  '';
+        };
+      });
+}


### PR DESCRIPTION
Leveraging `nix flake` and `direnv` to automatically setup the project environment.

it will download automatically (given you have `direnv` installed and allowed the folder, other wise you will have to type `nix develop` to get into the environment.) `F#`, `.NET SDK 8.0`, `NodeJS` & `PNPM` so you can start right away, without the need to install those dependencies system wide.

A possible next step could be to let nix build the project (i.e `nix build` && `nix run`) (for generating release/production version).

